### PR TITLE
Fix query for next/anytime

### DIFF
--- a/things3/things3.py
+++ b/things3/things3.py
@@ -177,10 +177,9 @@ class Things3():
                 f" TASK.{self.IS_ANYTIME} AND " + \
                 f" TASK.{self.IS_NOT_SCHEDULED} AND " + \
                 f" (" + \
-                f"  (PROJECT.title IS NULL OR (" + \
+                f"  ((PROJECT.title IS NULL AND HEADING.title IS NULL) OR (" + \
                 f"      PROJECT.{self.IS_ANYTIME} AND " + \
-                f"      PROJECT.{self.IS_NOT_SCHEDULED})) OR " + \
-                f"  HEADING.{self.IS_ANYTIME}" + \
+                f"      PROJECT.{self.IS_NOT_SCHEDULED}))" + \
                 f" ) " + \
                 f" ORDER BY TASK.duedate DESC , TASK.todayIndex"
         return self.get_rows(query)


### PR DESCRIPTION
From a user perspective, headings cannot be scheduled.
So I changed the query such that either tasks have no project and no heading, or the parent project is not Someday/Upcoming.
The case that a task *does* have a heading and *doesn't* have a project is not valid, so I omitted it.