### PR TITLE
add "status" key to get_rows()

### DIFF
--- a/things3/things3.py
+++ b/things3/things3.py
@@ -736,6 +736,11 @@ class Things3():
                     WHEN TASK.{self.IS_PROJECT} THEN 'project'
                     WHEN TASK.{self.IS_HEADING} THEN 'heading'
                 END AS type,
+                CASE
+                    WHEN TASK.{self.IS_OPEN} THEN 'open'
+                    WHEN TASK.{self.IS_CANCELLED} THEN 'cancelled'
+                    WHEN TASK.{self.IS_DONE} THEN 'done'
+                END AS status,
                 TASK.notes
             FROM
                 {self.TABLE_TASK} AS TASK

--- a/things3/things3_cli.py
+++ b/things3/things3_cli.py
@@ -47,7 +47,8 @@ class Things3CLI():
                           'type', 'due', 'created', 'modified', 'started',
                           'stopped', 'notes']
             writer = csv.DictWriter(
-                sys.stdout, fieldnames=fieldnames, delimiter=';')
+                sys.stdout, fieldnames=fieldnames, delimiter=';',
+                extrasaction='ignore')
             writer.writeheader()
             writer.writerows(tasks)
         else:


### PR DESCRIPTION
This is not used directly by KanbanView, but helpful for external apps that make use of the read-only things3.py API.